### PR TITLE
added dynamic post_process fn to endpoints resolves #4

### DIFF
--- a/lib/endpoint_store.js
+++ b/lib/endpoint_store.js
@@ -15,6 +15,10 @@ module.exports = function(config, es_service, index_name) {
         return es_service.search({index: index_name, q: '*'})
     }
 
+    function parseFn(fnString) {
+        return new Function(`return ${fnString}`)();
+    }
+
     function findRoute(route) {
         var index = null;
 
@@ -54,13 +58,17 @@ module.exports = function(config, es_service, index_name) {
                         else {
                             //check if config is the same, if not then change the handle function for the route
                             if (!_.isEqual(config, currentEndpoints[key])) {
-                                logger.warn(`Configuration for endpoint ${key} has changed, changing its handle`)
+                                logger.warn(`Configuration for endpoint ${key} has changed, changing its handle`);
                                 let index = findRoute(key);
 
                                 app._router.stack[index].handle = function endpoint(req, res) {
                                     var queryConfig = _.assign({}, currentEndpoints[key]);
                                     queryConfig.es_client = client;
 
+                                    if (queryConfig.post_process) {
+                                        queryConfig.post_process = parseFn(queryConfig.post_process)
+                                    }
+                                    // instantiate fn here
                                     search.luceneQuery(req, res, config.index, queryConfig);
                                 }
                             }
@@ -75,6 +83,10 @@ module.exports = function(config, es_service, index_name) {
                             app.use(config.endpoint, function endpoint(req, res) {
                                 var queryConfig = _.assign({}, config);
                                 queryConfig.es_client = client;
+
+                                if (queryConfig.post_process) {
+                                    queryConfig.post_process = parseFn(queryConfig.post_process);
+                                }
 
                                 search.luceneQuery(req, res, config.index, queryConfig);
                             });

--- a/lib/mappings/endpoint.json
+++ b/lib/mappings/endpoint.json
@@ -34,6 +34,10 @@
         "date_range": {
           "type": "string",
           "index": "not_analyzed"
+        },
+        "post_process": {
+          "type": "string",
+          "index": "not_analyzed"
         }
       }
     }


### PR DESCRIPTION
 client.update({index: 'teraserver__endpoints', type: 'endpoint', id: 'AVyhwKlIB_N7F7OpOuBC', body: {doc: {"post_process": "function change(data){ return data.map(obj => obj.url)}"}}})


this is an example of adding a post_process function to an endpoint that will adjust the endpoint

With this only url's will return